### PR TITLE
Extend the stratification checker to complain about higher-order arguments

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -48,7 +48,7 @@ let () =
   maybe_make_version_file () ;
   dispatch begin function
     | After_rules ->
-      flag ["ocaml" ; "compile"] (S [A "-annot" ; A "-g"]) ;
+      flag ["ocaml" ; "compile"] (S [A "-bin-annot" ; A "-g"]) ;
       flag ["ocaml" ; "link"] (A "-g") ;
       if Sys.os_type = "Unix" then
            flag ["ocaml" ; "compile"] (S [A "-w" ; A "@3@5@6@8..12@14@20@26@28@29"]) ;

--- a/src/extensions.ml
+++ b/src/extensions.ml
@@ -59,6 +59,9 @@ module String = struct
     let count = ref 0 in
       String.iter (fun c -> if c = char then incr count) str ;
       !count
+
+  module Map = Map.Make (String)
+  module Set = Set.Make (String)
 end
 
 module List = struct

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -603,8 +603,8 @@ let update_self_bound_vars () =
   sequent.vars <-
     sequent.vars |> List.map
         (fun (id, term) ->
-           match term_head_var term with
-             | Some v when term_to_name v = id ->
+           match term_head term with
+             | Some (v, _) when term_to_name v = id ->
                  (id, v)
              | _ -> (id, term))
 

--- a/src/term.mli
+++ b/src/term.mli
@@ -26,6 +26,7 @@ val tyarrow : ty list -> ty -> ty
 val tybase : string -> ty
 val oty : ty
 val olistty : ty
+val propty : ty
 
 (* Variables *)
 
@@ -139,7 +140,7 @@ val is_free : term -> bool
 val is_nominal_name : string -> bool
 val is_nominal : term -> bool
 val fresh_name : string -> (string * 'a) list -> string
-val term_head_var : term -> term option
+val term_head : term -> (term * term list) option
 val is_head_name : string -> term -> bool
 val term_head_name : term -> string
 


### PR DESCRIPTION
The following definitions now cause warnings:

```
Define bad : prop -> prop by
  bad P := bad P -> false.

Define ugly : prop by
  ugly := (ugly -> false) -> false.

Define not : prop -> prop by
  not P := P -> false.

Define r1 : prop -> prop by
  r1 P := P.  /* no warning here */

Define r2 : prop -> prop by
  r2 P := r1 P -> false.
```

The compile-time flag `Abella.stratification_warnings_are_errors` can be used to turn stratification warnings into errors. Currently this is set to `false` for backwards compatibility.
