### PR TITLE
Bring part of the test suite up to date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/version.ml
 src/abella
 src/unit_test
 abella
+tester
 _build
 examples/examples.tar.gz
 /src/outtakes.ml

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ clean:
 	$(OCB) -clean
 	$(RM) src/version.ml
 	$(RM) abella abella.exe
+	$(RM) tester tester.exe
 
 .PHONY: byte
 byte:
@@ -33,3 +34,12 @@ gitclean:
 top: all
 	$(OCB) src/abella.cma
 	ocaml
+
+.PHONY: test
+test:
+	$(OCB) -no-links -Is src,test,test/ext -lib unix test/test.native
+	if file _build/test/test.native | grep Windows >/dev/null 2>&1 ; then \
+	  cp _build/test/test.native tester.exe ; \
+	else \
+	  cp -a _build/test/test.native tester ; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ top: all
 	ocaml
 
 .PHONY: test
-test:
+test: all
 	$(OCB) -no-links -Is src,test,test/ext -lib unix test/test.native
 	if file _build/test/test.native | grep Windows >/dev/null 2>&1 ; then \
 	  cp _build/test/test.native tester.exe ; \

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -138,6 +138,7 @@
 
 
 %start lpmod lpsig defs top_command command any_command sig_body mod_body search_witness depth_spec
+%start term metaterm /*HACK To get the current test suites to compile! */
 %type <Typing.uterm> term
 %type <Typing.umetaterm> metaterm
 %type <Abella_types.lpsig> lpsig

--- a/test/test.ml
+++ b/test/test.ml
@@ -9,7 +9,7 @@ let tests = "Abella" >:::
     Test_graph.tests ;
     Test_subordination.tests ;
     Test_metaterm.tests ;
-    (*TODO Test_typing.tests ;*)
+    Test_typing.tests ;
     Test_parser.tests ;
     (*TODO Test_tactics.tests ;*)
     (*TODO Test_prover.tests ;*)

--- a/test/test.ml
+++ b/test/test.ml
@@ -10,7 +10,7 @@ let tests = "Abella" >:::
     Test_subordination.tests ;
     Test_metaterm.tests ;
     (*TODO Test_typing.tests ;*)
-    (*TODO Test_parser.tests ;*)
+    Test_parser.tests ;
     (*TODO Test_tactics.tests ;*)
     (*TODO Test_prover.tests ;*)
   ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,16 +3,16 @@ open Test_helper
 
 let tests = "Abella" >:::
   [
-    Unify_test.tests ;
-    Term_test.tests ;
-    Context_test.tests ;
-    Graph_test.tests ;
-    Subordination_test.tests ;
-    Metaterm_test.tests ;
-    Typing_test.tests ;
-    Parser_test.tests ;
-    Tactics_test.tests ;
-    Prover_test.tests ;
+    (*Test_unify.tests ; other compiler errors *)
+    (*Test_term.tests ; Parser must define term as %start *)
+    Test_context.tests ;
+    Test_graph.tests ;
+    Test_subordination.tests ;
+    (*Test_metaterm.tests ; Parser must define metaterm as %start *)
+    (*Test_typing.tests ; other compiler errors *)
+    (*Test_parser.tests ; other compiler errors *)
+    (*Test_tactics.tests ; other compiler errors *)
+    (*Test_prover.tests ; other compiler errors *)
   ]
 
 let tests = extract_tests [] tests

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,16 +3,16 @@ open Test_helper
 
 let tests = "Abella" >:::
   [
-    (*Test_unify.tests ; other compiler errors *)
-    (*Test_term.tests ; Parser must define term as %start *)
+    (*TODO Test_unify.tests ;*)
+    Test_term.tests ;
     Test_context.tests ;
     Test_graph.tests ;
     Test_subordination.tests ;
-    (*Test_metaterm.tests ; Parser must define metaterm as %start *)
-    (*Test_typing.tests ; other compiler errors *)
-    (*Test_parser.tests ; other compiler errors *)
-    (*Test_tactics.tests ; other compiler errors *)
-    (*Test_prover.tests ; other compiler errors *)
+    Test_metaterm.tests ;
+    (*TODO Test_typing.tests ;*)
+    (*TODO Test_parser.tests ;*)
+    (*TODO Test_tactics.tests ;*)
+    (*TODO Test_prover.tests ;*)
   ]
 
 let tests = extract_tests [] tests

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,7 +3,7 @@ open Test_helper
 
 let tests = "Abella" >:::
   [
-    (*TODO Test_unify.tests ;*)
+    Test_unify.tests ;
     Test_term.tests ;
     Test_context.tests ;
     Test_graph.tests ;

--- a/test/test_helper.ml
+++ b/test/test_helper.ml
@@ -36,21 +36,21 @@ let parse_udefs str =
 let parse_defs str =
   type_udefs ~sr:!sr ~sign:!sign (parse_udefs str)
 
-let eval_sig_string = "
-  kind      tm        type.
-  type      app       tm -> tm -> tm.
-  type      abs       (tm -> tm) -> tm.
-
-  kind      ty        type.
-  type      arrow     ty -> ty -> ty.
-
-  type      typeof    tm -> ty -> o.
+let eval_sig_string = "\
+  kind      tm        type.\
+  type      app       tm -> tm -> tm.\
+  type      abs       (tm -> tm) -> tm.\
+\
+  kind      ty        type.\
+  type      arrow     ty -> ty -> ty.\
+\
+  type      typeof    tm -> ty -> o.\
   type      eval      tm -> tm -> o."
 
-let eval_clauses_string = "
-  typeof (abs R) (arrow T U) :- pi x\\ (typeof x T => typeof (R x) U).
-  typeof (app M N) T :- typeof M (arrow U T), typeof N U.
-  eval (abs R) (abs R).
+let eval_clauses_string = "\
+  typeof (abs R) (arrow T U) :- pi x\\ (typeof x T => typeof (R x) U).\
+  typeof (app M N) T :- typeof M (arrow U T), typeof N U.\
+  eval (abs R) (abs R).\
   eval (app M N) V :- eval M (abs R), eval (R N) V."
 
 let process_decls decls =
@@ -64,30 +64,30 @@ let () = process_decls (parse_decls eval_sig_string)
 
 let eval_clauses = parse_clauses eval_clauses_string
 
-let extra_sig_string = "
-  kind       i                     type.
-
-  type       t1, t2, t3, t4        i.
-  type       r1, r2                i -> i.
-
-  type       iabs                  (i -> i) -> i.
-  type       iapp                  i -> i -> i.
-
-  type       a, b, c, d            o.
-  type       p1, p2, p3            i -> o.
-  type       hyp, conc, form       i -> o.
-
+let extra_sig_string = "\
+  kind       i                     type.\
+\
+  type       t1, t2, t3, t4        i.\
+  type       r1, r2                i -> i.\
+\
+  type       iabs                  (i -> i) -> i.\
+  type       iapp                  i -> i -> i.\
+\
+  type       a, b, c, d            o.\
+  type       p1, p2, p3            i -> o.\
+  type       hyp, conc, form       i -> o.\
+\
   type       eq, pr                i -> i -> o."
 
 let () = process_decls (parse_decls extra_sig_string)
 
-let nat_sig_string = "
-  kind       nat                  type.
-
-  type       z                    nat.
-  type       s                    nat -> nat.
-
-  type       nat, even, odd       nat -> o.
+let nat_sig_string = "\
+  kind       nat                  type.\
+\
+  type       z                    nat.\
+  type       s                    nat -> nat.\
+\
+  type       nat, even, odd       nat -> o.\
   type       add                  nat -> nat -> nat -> o."
 
 let () = process_decls (parse_decls nat_sig_string)

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -21,7 +21,7 @@ let tests =
         (fun () ->
            let str = "eval (abs R) (abs R)." in
              match parse_uclauses str with
-               | [(t, [])] ->
+               | [(None, t, [])] ->
                    assert_uterm_pprint_equal "eval (abs R) (abs R)" t
                | _ -> assert_failure "Pattern mismatch" ) ;
 
@@ -29,7 +29,7 @@ let tests =
         (fun () ->
            let str = "eval (app M N) V :- eval M (abs R), eval (R N) V." in
              match parse_uclauses str with
-               | [(head, [b1; b2])] ->
+               | [(None, head, [b1; b2])] ->
                    assert_uterm_pprint_equal "eval (app M N) V" head ;
                    assert_uterm_pprint_equal "eval M (abs R)" b1 ;
                    assert_uterm_pprint_equal "eval (R N) V" b2 ;

--- a/test/test_typing.ml
+++ b/test/test_typing.ml
@@ -31,7 +31,7 @@ let tests =
       "Should not allow pi quantification over o in clause" >::
         (fun () ->
            let uclause =
-             (ucon "a", [uapp (ucon "pi") (ulam "x" ~ty:oty (ucon "x"))])
+             (None, ucon "a", [uapp (ucon "pi") (ulam "x" ~ty:oty (ucon "x"))])
            in
              assert_raises
                (Failure "Cannot quantify over type o in the specification logic")
@@ -61,11 +61,12 @@ let tests =
       "Should replace underscores in clauses with fresh names" >::
         (fun () ->
            let uclause =
-             (uapp (ucon "p1") (ucon "X"),
+             (None,
+              uapp (ucon "p1") (ucon "X"),
               [uapp (uapp (ucon "pr") (ucon "_")) (ucon "_")])
            in
              let clause = type_uclause ~sr:!sr ~sign:!sign uclause in
-             match Tactics.clausify clause with
+             match Metaterm.clausify clause with
                | _, _, p::_ ->
                    assert_term_pprint_equal "pr X1 X2" p
                | _ -> assert false

--- a/test/test_unify.ml
+++ b/test/test_unify.ml
@@ -374,7 +374,7 @@ let tests =
              assert_term_pprint_equal "X" x ;
              assert_term_pprint_equal "X" y ;
              match observe x, observe y with
-               | Var {ts=0}, Var {ts=0} -> ()
+               | Var {ts=0; _}, Var {ts=0; _} -> ()
                | _ -> assert_failure "Timestamps should be lowered to match") ;
 
       "[X^0 = p^0 Y^1 Z^1]" >::
@@ -387,7 +387,7 @@ let tests =
              right_unify ~used x (p ^^ [y; z]) ;
              assert_term_pprint_equal "p X1 X2" x ;
              match observe y, observe z with
-               | Var {ts=0}, Var {ts=0} -> ()
+               | Var {ts=0; _}, Var {ts=0; _} -> ()
                | _ -> assert_failure "Timestamps should be lowered to match") ;
 
       "X^0 = f^0 a^1" >::
@@ -585,7 +585,7 @@ let tests =
              right_unify ~used x ([("x1",ity)] // y) ;
              assert_term_pprint_equal "x1\\Y1" x ;
              match observe y with
-               | Var {ts=0} -> ()
+               | Var {ts=0; _} -> ()
                | _ -> assert_failure "Timestamp should be lowered to match") ;
 
       "R^0 N^0 = plus A^0 B^0" >::


### PR DESCRIPTION
As pointed out in #57, the Abella test suite is needing some attention. A few simple changes allow five out of ten test modules to compile. From a conversation with @chaudhuri it seems that the changes made to the parser are indeed correct.

A new target for make creates a tester executable that runs all the (current) tests in the battery. Although a simplified scenario, I am finding it helpful.