### PR TITLE
Fix tactic tests

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -144,7 +144,7 @@
 
 
 %start lpmod lpsig defs top_command command any_command sig_body mod_body search_witness depth_spec
-%start term metaterm /*HACK To get the current test suites to compile! */
+%start term metaterm
 %type <Typing.uterm> term
 %type <Typing.umetaterm> metaterm
 %type <Abella_types.lpsig> lpsig

--- a/test/test.ml
+++ b/test/test.ml
@@ -11,7 +11,7 @@ let tests = "Abella" >:::
     Test_metaterm.tests ;
     Test_typing.tests ;
     Test_parser.tests ;
-    (*TODO Test_tactics.tests ;*)
+    Test_tactics.tests ;
     (*TODO Test_prover.tests ;*)
   ]
 

--- a/test/test_helper.ml
+++ b/test/test_helper.ml
@@ -34,7 +34,8 @@ let parse_udefs str =
   Parser.defs Lexer.token (Lexing.from_string str)
 
 let parse_defs str =
-  type_udefs ~sr:!sr ~sign:!sign (parse_udefs str)
+  type_udefs ~sr:!sr ~sign:!sign (parse_udefs str) |>
+  List.map (fun (head, body) -> Abella_types.{head; body})
 
 let eval_sig_string = "\
   kind      tm        type.\

--- a/test/test_tactics.ml
+++ b/test/test_tactics.ml
@@ -1596,9 +1596,18 @@ let unfold ~defs goal =
     List.map (fun {Abella_types.head; _} -> def_head_name head) defs |>
     List.fold_left add_to_itab Itab.empty in
   let mdefs = (mutual, defs) in
-    unfold ~mdefs goal
+    unfold ~mdefs ~used:[] Abella_types.Select_any Abella_types.Solution_first
+      goal (*TODO*)
 
 let unfold_tests =
+
+  (* This assert refines (and hides) the original. If the tests should be made
+   * aware of it, or once the distinction must be made explicit, it can be
+   * renamed together with the calls in each test. *)
+  let assert_pprint_equal str result =
+     assert_int_equal (List.length result) 1 ;
+     assert_pprint_equal str (List.nth result 0) in
+
   "Unfold" >:::
     [
       "Should pick matching clause" >::

--- a/test/test_tactics.ml
+++ b/test/test_tactics.ml
@@ -244,8 +244,8 @@ let apply_tests =
       "With multiple nablas" >::
         (fun () ->
            let h0 =
-             freshen "forall A B, nabla x y,
-                        rel1 (iapp x y) (iapp (A x) (B y)) ->
+             freshen "forall A B, nabla x y,\
+                        rel1 (iapp x y) (iapp (A x) (B y)) ->\
                           rel2 (iabs A) (iabs B)"
            in
            let h1 = freshen "rel1 (iapp n1 n2) (iapp (C n1) (D n2))" in
@@ -1050,7 +1050,7 @@ let induction_tests =
       "Mutual on objects" >::
         (fun () ->
            let stmt = freshen
-             "(forall A, {hyp A} -> {conc A} -> {form A}) /\\
+             "(forall A, {hyp A} -> {conc A} -> {form A}) /\\\
               (forall B, {form B} -> {conc B})" in
              match induction [2; 1] 1 stmt with
                | [ih1; ih2], goal ->

--- a/test/test_tactics.ml
+++ b/test/test_tactics.ml
@@ -591,7 +591,7 @@ let case_tests =
         (fun () ->
            let term = freshen "{a} \\/ {b}" in
              match case term with
-               | [{new_hyps=[hyp1]} ; {new_hyps=[hyp2]}] ->
+               | [{new_hyps=[hyp1] ; _} ; {new_hyps=[hyp2] ; _}] ->
                    assert_pprint_equal "{a}" hyp1 ;
                    assert_pprint_equal "{b}" hyp2 ;
                | _ -> assert_failure "Pattern mismatch") ;
@@ -600,7 +600,8 @@ let case_tests =
         (fun () ->
            let term = freshen "{a} \\/ {b} \\/ {c}" in
              match case term with
-               | [{new_hyps=[hyp1]} ; {new_hyps=[hyp2]} ; {new_hyps=[hyp3]}] ->
+               | [{new_hyps=[hyp1] ; _} ; {new_hyps=[hyp2] ; _} ;
+                  {new_hyps=[hyp3] ; _}] ->
                    assert_pprint_equal "{a}" hyp1 ;
                    assert_pprint_equal "{b}" hyp2 ;
                    assert_pprint_equal "{c}" hyp3 ;
@@ -610,7 +611,7 @@ let case_tests =
         (fun () ->
            let term = freshen "A = B \\/ rel1 A B" in
              match case term with
-               | [{new_hyps=[]} ; {new_hyps=[hyp]}] ->
+               | [{new_hyps=[] ; _} ; {new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "rel1 A B" hyp ;
                | _ -> assert_failure "Pattern mismatch") ;
 
@@ -618,7 +619,7 @@ let case_tests =
         (fun () ->
            let term = freshen "{a} /\\ {b}" in
              match case term with
-               | [{new_hyps=[hyp1;hyp2]}] ->
+               | [{new_hyps=[hyp1;hyp2] ; _}] ->
                    assert_pprint_equal "{a}" hyp1 ;
                    assert_pprint_equal "{b}" hyp2 ;
                | _ -> assert_failure "Pattern mismatch") ;
@@ -627,7 +628,7 @@ let case_tests =
         (fun () ->
            let term = freshen "{a} /\\ {b} /\\ {c}" in
              match case term with
-               | [{new_hyps=[hyp1;hyp2;hyp3]}] ->
+               | [{new_hyps=[hyp1;hyp2;hyp3] ; _}] ->
                    assert_pprint_equal "{a}" hyp1 ;
                    assert_pprint_equal "{b}" hyp2 ;
                    assert_pprint_equal "{c}" hyp3 ;
@@ -638,7 +639,7 @@ let case_tests =
            let term = freshen "exists A B, rel1 A B" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=new_vars ; new_hyps=[hyp]}] ->
+               | [{new_vars=new_vars ; new_hyps=[hyp] ; _}] ->
                    let var_names = List.map fst new_vars in
                      assert_string_list_equal ["A"; "B"] var_names ;
                      assert_pprint_equal "rel1 A B" hyp ;
@@ -649,7 +650,7 @@ let case_tests =
            let term = freshen "exists A B, foo A /\\ bar B" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=new_vars ; new_hyps=[hyp1; hyp2]}] ->
+               | [{new_vars=new_vars ; new_hyps=[hyp1; hyp2] ; _}] ->
                    let var_names = List.map fst new_vars in
                      assert_string_list_equal ["A"; "B"] var_names ;
                      assert_pprint_equal "foo A" hyp1 ;
@@ -661,7 +662,7 @@ let case_tests =
            let term = freshen "{a} /\\ exists B, bar B" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=new_vars ; new_hyps=[hyp1; hyp2]}] ->
+               | [{new_vars=new_vars ; new_hyps=[hyp1; hyp2] ; _}] ->
                    let var_names = List.map fst new_vars in
                      assert_string_list_equal ["B"] var_names ;
                      assert_pprint_equal "{a}" hyp1 ;
@@ -673,7 +674,7 @@ let case_tests =
            let term = freshen "nabla x, foo x" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=[] ; new_hyps=[hyp]}] ->
+               | [{new_vars=[] ; new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "foo n1" hyp ;
                | _ -> assert_failure "Pattern mismatch") ;
 
@@ -682,7 +683,7 @@ let case_tests =
            let term = freshen "nabla x y, rel1 x y" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=[] ; new_hyps=[hyp]}] ->
+               | [{new_vars=[] ; new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "rel1 n1 n2" hyp ;
                | _ -> assert_failure "Pattern mismatch") ;
 
@@ -691,7 +692,7 @@ let case_tests =
            let term = freshen "nabla x, exists A, rel1 x A" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=new_vars ; new_hyps=[hyp]}] ->
+               | [{new_vars=new_vars ; new_hyps=[hyp] ; _}] ->
                    let var_names = List.map fst new_vars in
                      assert_string_list_equal ["A"] var_names ;
                      assert_pprint_equal "rel1 n1 (A n1)" hyp ;
@@ -702,7 +703,7 @@ let case_tests =
            let term = freshen "nabla x, rel1 n1 x" in
            let used = [] in
              match case ~used term with
-               | [{new_vars=[] ; new_hyps=[hyp]}] ->
+               | [{new_vars=[] ; new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "rel1 n1 n2" hyp ;
                | _ -> assert_failure "Pattern mismatch") ;
 
@@ -710,7 +711,7 @@ let case_tests =
         (fun () ->
            let term = freshen "{L, hyp A |- hyp B}" in
              match case term with
-               | [{new_vars=[] ; new_hyps=[hyp]}] ->
+               | [{new_vars=[] ; new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "member (hyp B) (hyp A :: L)" hyp
                | _ -> assert_failure "Pattern mismatch") ;
 
@@ -718,7 +719,7 @@ let case_tests =
         (fun () ->
            let term = freshen "{L |- p1 A}@" in
              match case term with
-               | [{new_vars=[] ; new_hyps=[hyp]}] ->
+               | [{new_vars=[] ; new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "member (p1 A) L" hyp
                | _ -> assert_failure "Pattern mismatch") ;
 
@@ -763,7 +764,7 @@ let case_tests =
            let term = freshen "exists A, rel1 A n1" in
            let used = [] in
              match case ~used term with
-               | [{new_hyps=[hyp]}] ->
+               | [{new_hyps=[hyp] ; _}] ->
                    assert_pprint_equal "rel1 (A n1) n1" hyp
                | _ -> assert_failure "Pattern mismatch") ;
 

--- a/test/test_tactics.ml
+++ b/test/test_tactics.ml
@@ -1108,10 +1108,13 @@ let assert_search ?(clauses="") ?(defs="")
     List.map (fun {Abella_types.head; _} -> def_head_name head) defs |>
     List.fold_left add_to_itab Itab.empty
   in
-  let alldefs = [(mutual, defs)] in
+  let def_unfold _ = (mutual, defs) in (*TODO*)
   let hyps = List.map (fun h -> ("", h)) (List.map freshen hyps) in
+  let retype t = Typing.uterm_to_term [] t in (*TODO*)
   let goal = freshen goal in
-  let actual = Option.is_some (search ~depth ~hyps ~clauses ~alldefs goal) in
+  let actual = Option.is_some
+    (search ~depth ~hyps ~clauses ~def_unfold ~retype goal)
+  in
     if expect then
       assert_bool "Search should succeed" actual
     else


### PR DESCRIPTION
Continuing the work described in #57, this series of commits revisits the tests on tactics to make them build and run once again. Each commit focuses on one separate problem, and should be easy to review separately.

The sub-collections of tests on search and unfold deserve special mention. Here, changes to module interfaces have been more profound than elsewhere. In general, the simplest reasonable conversions suffice to get the code to compile and all affected tests to pass, but may not exercise all possible paths and tests to ensure the correctness of these conversions in the general case may be added. See `(*TODO*)` markers for details.

Once integrated, issues for the new regressions will follow.