### PR TITLE
Non iterative use of search depth bound

### DIFF
--- a/src/prover.ml
+++ b/src/prover.ml
@@ -711,18 +711,15 @@ let search_goal_witness ?depth goal witness =
              |> List.map (fun h -> (h.id, h.term))
   in
   let depth = Option.default !search_depth depth in
-  let search_depth n =
-    Tactics.search
-      ~depth:n
-      ~hyps
-      ~clauses:!clauses
-      ~def_unfold
-      ~sr:!sr
-      ~retype
-      ~witness
-      goal
-  in
-  List.find_some search_depth (List.range 1 depth)
+  Tactics.search
+    ~depth
+    ~hyps
+    ~clauses:!clauses
+    ~def_unfold
+    ~sr:!sr
+    ~retype
+    ~witness
+    goal
 
 let search_goal ?depth goal =
   try Option.is_some (search_goal_witness ?depth goal WMagic)


### PR DESCRIPTION
This commit modifies the internal behavior of the search tactic (while
preserving its semantics) by moving from IDDFS on the range of dephts
from 1 to the effective maximum depth to a single execution of
Tactics.search on said maximum depth.

The rationale for this change is the following. If an explicit bound is
not given, the system falls back to the (small) default, and any penalty
incurred by trying to explore deeper and initially missing shallow
solutions is negligible.

If, on the other hand, an explicit bound is given, the responsibility
for its adequacy falls on the user, as do any adverse effects of
excessive slack on runtime. On the upside, this strategy avoids the
quadratic time factor that results from multiple executions of the
search tactic with increasing bounds, which becomes problematic for
higher values of these.