### PR TITLE
Increment unprotected dB indexes in abstract

### DIFF
--- a/src/term.ml
+++ b/src/term.ml
@@ -246,17 +246,18 @@ let unwind_state f x =
   result
 
 (* Recursively raise dB indices and abstract over variables
- * selected by [test]. *)
+ * selected by [test]. Indices unprotected by abstractions
+ * are incremented. *)
 let abstract test =
-  let rec aux n t = match t with
-    | DB i -> t
-    | App(h,ts) -> App(aux n h, List.map (aux n) ts)
-    | Lam(idtys,s) -> Lam (idtys, aux (n + List.length idtys) s)
-    | Ptr {contents=T t} -> Ptr (ref (T (aux n t)))
+  let rec aux ~inc_i n t = match t with
+    | DB i -> DB (if inc_i then i + 1 else i)
+    | App(h,ts) -> App(aux ~inc_i n h, List.map (aux ~inc_i n) ts)
+    | Lam(idtys,s) -> Lam (idtys, aux ~inc_i:false (n + List.length idtys) s)
+    | Ptr {contents=T t} -> Ptr (ref (T (aux ~inc_i n t)))
     | Ptr {contents=V v} -> if test t v.name then DB n else t
     | Var _ -> assert false
     | Susp _ -> assert false
-  in aux
+  in aux ~inc_i:true
 
 (** Abstract [t] over constant or variable named [id]. *)
 let abstract id ty t =

--- a/src/term.ml
+++ b/src/term.ml
@@ -249,15 +249,15 @@ let unwind_state f x =
  * selected by [test]. Indices unprotected by abstractions
  * are incremented. *)
 let abstract test =
-  let rec aux ~inc_i n t = match t with
-    | DB i -> DB (if inc_i then i + 1 else i)
-    | App(h,ts) -> App(aux ~inc_i n h, List.map (aux ~inc_i n) ts)
-    | Lam(idtys,s) -> Lam (idtys, aux ~inc_i:false (n + List.length idtys) s)
-    | Ptr {contents=T t} -> Ptr (ref (T (aux ~inc_i n t)))
+  let rec aux n t = match t with
+    | DB i -> DB (if i < n then i else i + 1)
+    | App(h,ts) -> App(aux n h, List.map (aux n) ts)
+    | Lam(idtys,s) -> Lam (idtys, aux (n + List.length idtys) s)
+    | Ptr {contents=T t} -> Ptr (ref (T (aux n t)))
     | Ptr {contents=V v} -> if test t v.name then DB n else t
     | Var _ -> assert false
     | Susp _ -> assert false
-  in aux ~inc_i:true
+  in aux
 
 (** Abstract [t] over constant or variable named [id]. *)
 let abstract id ty t =

--- a/test/test_term.ml
+++ b/test/test_term.ml
@@ -49,7 +49,6 @@ let norm_tests =
            let t = t ^^ [ 2 /// (db 2 ^^ [db 1]) ] in
            let t = hnorm t in
              assert_term_equal (1 /// ((1 /// db 1) ^^ [db 1]))  t) ;
-
       "[(x\\ x (x\\ x)) (x\\y\\ x y) c]" >::
         (fun () ->
            let c = uconst "c" in
@@ -171,5 +170,26 @@ let binding_tests =
                (fun () -> bind v2 v1)) ;
     ]
 
+let abstract_tests =
+  "Abstract" >:::
+    [
+      "Should not capture unprotected dB's" >::
+        (fun () ->
+          let g = uconst "g" in
+          let h = uconst "h" in
+          let x = uconst "X" in
+          let t = db 1 ^^ [(g ^^ [1 /// (h ^^ [db 1; x])])] in
+          let actual = abstract "X" emptyty t in
+          let expected = 1 /// (db 2 ^^ [(g ^^ [1 /// (h ^^ [db 1; db 2])])]) in
+          assert_term_equal expected actual) ;
+    ]
+
 let tests =
-  "Term" >::: [norm_tests; pprint_tests; typing_tests; binding_tests]
+  "Term" >:::
+    [
+      norm_tests;
+      pprint_tests;
+      typing_tests;
+      binding_tests;
+      abstract_tests
+    ]

--- a/test/test_term.ml
+++ b/test/test_term.ml
@@ -173,14 +173,28 @@ let binding_tests =
 let abstract_tests =
   "Abstract" >:::
     [
-      "Should not capture unprotected dB's" >::
+      "Should not capture unprotected dB's (single layer)" >::
         (fun () ->
           let g = uconst "g" in
           let h = uconst "h" in
           let x = uconst "X" in
+          (*    `1 (g (y\ h `1 X)) *)
           let t = db 1 ^^ [(g ^^ [1 /// (h ^^ [db 1; x])])] in
           let actual = abstract "X" emptyty t in
+          (* x\ `2 (g (y\ h y  x)) *)
           let expected = 1 /// (db 2 ^^ [(g ^^ [1 /// (h ^^ [db 1; db 2])])]) in
+          assert_term_equal expected actual) ;
+
+      "Should not capture unprotected dB's (multilayer)" >::
+        (fun () ->
+          let x = uconst "X" in
+          let y = uconst "Y" in
+          let z = uconst "Z" in
+          (*       X `1 (w\ Y w) Z *)
+          let t = x ^^ [db 1; (1 /// (y ^^ [db 1])); z] in
+          let actual = abstract "Y" emptyty (abstract "Z" emptyty t) in
+          (* y\ z\ X `3 (w\ y w) z *)
+          let expected = 2 /// (x ^^ [db 3; (1 /// (db 3 ^^ [db 1])); db 1]) in
           assert_term_equal expected actual) ;
     ]
 


### PR DESCRIPTION
The problem occurs in those DB subterms that the recursive function does
not see as protected by a binder. For example:

  abstract "X" ty (`1 (g (y\ h `1 X))) ->
  x\ `1 (g (y\ h `1 `2) ->
  x\ x (g (y\ y x))

So there is a capture at the top that was not envisioned by the method.
These "unprotected DBs" are to be incremented to account for the new
lambda that will wrap the resulting term.

This commit addresses issue #82.