### PR TITLE
Remove Term.norm

### DIFF
--- a/src/term.ml
+++ b/src/term.ml
@@ -164,13 +164,6 @@ let rec hnorm term =
           end
     | Ptr _ -> assert false
 
-let rec norm t =
-  match observe (hnorm t) with
-  | (Var _ | DB _) as t -> t
-  | App (f, ts) -> App (norm f, List.map norm ts)
-  | Lam (cx, t) -> Lam (cx, norm t)
-  | _ -> assert false
-
 let rec eq t1 t2 =
   match observe (hnorm t1), observe (hnorm t2) with
     | DB i1, DB i2 -> i1 = i2

--- a/src/term.mli
+++ b/src/term.mli
@@ -139,7 +139,6 @@ val has_logic_head : term -> bool
 val has_eigen_head : term -> bool
 
 val hnorm : term -> term
-val norm : term -> term
 
 val pretty_ty : ty -> Pretty.expr
 val format_ty : Format.formatter -> ty -> unit


### PR DESCRIPTION
Partially addresses #86. Term.norm is not used anywhere in the Abella
codebase, its effects can be replicated by the standard observe-hnorm
pattern, and it can produce invalid term structures: it is therefore
removed. All tests pass.