### PR TITLE
Feature: tactic `applys` as a handy version of `apply`

### DIFF
--- a/src/abella.ml
+++ b/src/abella.ml
@@ -605,7 +605,7 @@ and process_proof1 name =
   begin match input with
   | Induction(args, hn)           -> Prover.induction ?name:hn args
   | CoInduction hn                -> Prover.coinduction ?name:hn ()
-  | Apply(depth, h, args, ws, hn) -> Prover.apply ?depth ?name:hn h args ws ~term_witness
+  | Apply(depth, h, args, ws, hn, applys) -> Prover.apply ~applys ?depth ?name:hn h args ws ~term_witness
   | Backchain(depth, h, ws)       -> Prover.backchain ?depth h ws ~term_witness
   | Cut(h, arg, hn)               -> Prover.cut ?name:hn h arg
   | CutFrom(h, arg, t, hn)        -> Prover.cut_from ?name:hn h arg t

--- a/src/abella_types.ml
+++ b/src/abella_types.ml
@@ -138,7 +138,7 @@ type hhint = id option
 type command =
   | Induction of int list * hhint
   | CoInduction of id option
-  | Apply of depth_bound option * clearable * clearable list * (id * uterm) list * hhint
+  | Apply of depth_bound option * clearable * clearable list * (id * uterm) list * hhint * bool (* false: apply; true: applys *)
   | Backchain of depth_bound option * clearable * (id * uterm) list
   | CutFrom of clearable * clearable * uterm * hhint
   | Cut of clearable * clearable * hhint
@@ -308,10 +308,11 @@ let command_to_string c =
           (String.concat " " (List.map string_of_int is))
     | CoInduction None -> "coinduction"
     | CoInduction (Some hn) -> "coinduction " ^ hn
-    | Apply(dbound, h, hs, ws, hn) -> begin
+    | Apply(dbound, h, hs, ws, hn, applys) -> begin
         let buf = Buffer.create 10 in
         Buffer.add_string buf (hn_to_string hn) ;
         Buffer.add_string buf "apply" ;
+        if applys then Buffer.add_string buf "s" ;
         Buffer.add_string buf (dbound_to_string dbound) ;
         Buffer.add_string buf (" " ^ clearable_to_string h) ;
         if hs <> [] then

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -44,6 +44,7 @@
     "accumulate",    ACCUM ;
     "all",           ALL ;
     "apply",         APPLY ;
+    "applys",        APPLYS ;
     "as",            AS ;
     "assert",        ASSERT ;
     "async",         ASYNC ;

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -108,7 +108,7 @@
 %}
 
 %token IMP IF AMP COMMA DOT BSLASH LPAREN RPAREN TURN CONS EQ TRUE FALSE DEFEQ
-%token IND INST APPLY CASE FROM SEARCH TO ON WITH INTROS CUT ASSERT CLAUSEEQ
+%token IND INST APPLY APPLYS CASE FROM SEARCH TO ON WITH INTROS CUT ASSERT CLAUSEEQ
 %token SKIP UNDO ABORT COIND LEFT RIGHT MONOTONE IMPORT BY ASYNC
 %token SPLIT SPLITSTAR UNFOLD ALL KEEP CLEAR SPECIFICATION SEMICOLON
 %token THEOREM DEFINE PLUS CODEFINE SET ABBREV UNABBREV QUERY SHOW
@@ -172,6 +172,7 @@ id:
   | ABORT         { "abort" }
   | ALL           { "all" }
   | APPLY         { "apply" }
+  | APPLYS        { "applys" }
   | AS            { "as" }
   | ASSERT        { "assert" }
   | ASYNC         { "async" }
@@ -484,14 +485,25 @@ pure_command:
     { Types.Induction($4, $1) }
   | hhint COIND DOT
     { Types.CoInduction($1) }
+
   | hhint APPLY maybe_depth clearable TO apply_args DOT
-    { Types.Apply($3, $4, $6, [], $1) }
+    { Types.Apply($3, $4, $6, [], $1, false) }
   | hhint APPLY maybe_depth clearable TO apply_args WITH withs DOT
-    { Types.Apply($3, $4, $6, $8, $1) }
+    { Types.Apply($3, $4, $6, $8, $1, false) }
   | hhint APPLY maybe_depth clearable WITH withs DOT
-    { Types.Apply($3, $4, [], $6, $1) }
+    { Types.Apply($3, $4, [], $6, $1, false) }
   | hhint APPLY maybe_depth clearable DOT
-    { Types.Apply($3, $4, [], [], $1) }
+    { Types.Apply($3, $4, [], [], $1, false) }
+    
+  | hhint APPLYS maybe_depth clearable TO apply_args DOT
+    { Types.Apply($3, $4, $6, [], $1, true) }
+  | hhint APPLYS maybe_depth clearable TO apply_args WITH withs DOT
+    { Types.Apply($3, $4, $6, $8, $1, true) }
+  | hhint APPLYS maybe_depth clearable WITH withs DOT
+    { Types.Apply($3, $4, [], $6, $1, true) }
+  | hhint APPLYS maybe_depth clearable DOT
+    { Types.Apply($3, $4, [], [], $1, true) }
+
   | BACKCHAIN maybe_depth clearable DOT
     { Types.Backchain($2, $3, []) }
   | BACKCHAIN maybe_depth clearable WITH withs DOT

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -499,6 +499,10 @@ pure_command:
     { Types.Apply($3, $4, $6, [], $1, true) }
   | hhint APPLYS maybe_depth clearable TO apply_args WITH withs DOT
     { Types.Apply($3, $4, $6, $8, $1, true) }
+  | hhint APPLYS maybe_depth clearable apply_args DOT
+    { Types.Apply($3, $4, $5, [], $1, true) }
+  | hhint APPLYS maybe_depth clearable apply_args WITH withs DOT
+    { Types.Apply($3, $4, $5, $7, $1, true) }
   | hhint APPLYS maybe_depth clearable WITH withs DOT
     { Types.Apply($3, $4, [], $6, $1, true) }
   | hhint APPLYS maybe_depth clearable DOT

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -797,9 +797,10 @@ let apply ?applys:(applys=false) ?depth ?name ?(term_witness=ignore) h args ws =
   (* (if applys = true then failwith "applys not implemented"); *)
   let stmt = get_stmt_clearly h in
   let args = List.map get_arg_clearly args in
+  let hyp_tms = List.map (fun h -> h.term) sequent.hyps in
   let () = List.iter (Option.map_default ensure_no_restrictions ()) args in
   let ws = type_apply_withs stmt ws in
-  let result, obligations = Tactics.apply_with stmt args ws ~applys in
+  let result, obligations = Tactics.apply_with stmt args ws hyp_tms ~applys in
   let remaining_obligations, term_witnesses =
     partition_obligations ?depth obligations
   in

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -746,7 +746,7 @@ let goal_to_subgoal g =
 let ensure_no_logic_variable terms =
   let logic_vars = List.flatten_map (metaterm_vars_alist Logic) terms in
   if logic_vars <> [] then
-    failwith "Found logic variable at toplevel"
+    failwith ("Found " ^ string_of_int (List.length logic_vars) ^ " logic variables at toplevel")
 
 let ensure_no_restrictions term =
   let rec aux t nested =
@@ -793,12 +793,13 @@ let partition_obligations ?depth obligations =
           | Some w -> Either.Right (g, w))
        obligations)
 
-let apply ?depth ?name ?(term_witness=ignore) h args ws =
+let apply ?applys:(applys=false) ?depth ?name ?(term_witness=ignore) h args ws =
+  (* (if applys = true then failwith "applys not implemented"); *)
   let stmt = get_stmt_clearly h in
   let args = List.map get_arg_clearly args in
   let () = List.iter (Option.map_default ensure_no_restrictions ()) args in
   let ws = type_apply_withs stmt ws in
-  let result, obligations = Tactics.apply_with stmt args ws in
+  let result, obligations = Tactics.apply_with stmt args ws ~applys in
   let remaining_obligations, term_witnesses =
     partition_obligations ?depth obligations
   in

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1404,8 +1404,7 @@ let try_with_state_all ~fail f =
       | TypesNotFullyDetermined
         -> set_scoped_bind_state state ; fail
 
-let apply ?(applys=false) ?(used_nominals=[]) term args hyps =
-  let args = if not applys then args else genCompatibleArgs term args hyps in
+let apply ?(used_nominals=[]) term args =
   let hyp_support = metaterm_support term in
   let support = hyp_support @
                   List.flatten_map (Option.map_default metaterm_support []) args in
@@ -1515,11 +1514,12 @@ let rec instantiate_withs term withs =
   | _ -> (term, [])
 
 let apply_with ?applys:(applys=false) term args withs hyps =
-  if args = [] && withs = [] && not applys then
+  let args = if not applys then args else genCompatibleArgs term args hyps in
+  if args = [] && withs = [] then
     (term, [])
   else
-  let term, used_nominals = instantiate_withs term withs in
-  apply (normalize term) args hyps ~used_nominals ~applys
+    let term, used_nominals = instantiate_withs term withs in
+    apply (normalize term) args ~used_nominals
 
 (* Backchain *)
 

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1301,17 +1301,27 @@ let genCompatibleArgs term args hyps =
         Printf.printf " %s {%s} ~%B %s {%s}\n" (metaterm_to_string tm) (head2str tm) (compatible_metaterm tm a) (metaterm_to_string a) (head2str a)
     end terms args ;*)
   let argArr = Array.make (List.length terms) None in
+  let wildcardCounter = ref 0 in
+  (* interpret "_" as a indicator to skip match: `applys X to _ H` will match H with its second compatible term *)
   List.iter (function
       | Some a ->
+        let toSkip = !wildcardCounter in
+        wildcardCounter := 0;
+        let skipCnt = ref 0 in
         let pa = ref (-1) in
         List.iteri (fun i t ->
-          if !pa < 0 && argArr.(i) = None && compatible_metaterm t a then pa := i
+          if !pa < 0 && argArr.(i) = None && compatible_metaterm t a then
+          begin
+            if !skipCnt = toSkip then pa := i;
+            incr skipCnt
+          end
         ) terms;
         if !pa < 0 then
-          failwithf "Hypothesis [%s] is not compatible with any subgoal" (metaterm_to_string a)
+          let skipStr = if toSkip = 0 then "" else Printf.sprintf " (skip %d/%d)" toSkip !skipCnt in
+          failwithf "[%s] is not compatible with any subgoal%s" (metaterm_to_string a) skipStr
         else
           argArr.(!pa) <- Some a
-      | None -> ()
+      | None -> incr wildcardCounter
     ) args;
   (* Printf.printf "applys get %d args and produces %d terms\n" (List.length args) (Array.length argArr); *)
   (* Fix induction hyps *)

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1283,15 +1283,44 @@ let rec compatible_metaterm formal actual = match formal, actual with
   | Pred (fm, fr), Pred (am, ar) -> compatible_term fm am && compatible_restriction fr ar
   | _ -> false
 
-(* let term_head_nametag_str tm = 
-  ty_to_string (term_head_ty tm) ^ " " ^ term_head_name tm
+let genCompatibleArgs term args hyps =
+  (* naive: match first *)
+  let terms = (map_args (fun x -> x) term) in
+  (*
+    Printf.printf "Applying term: %s\n" (metaterm_to_string term);
+    List.iter2 begin fun tm arg ->
+      match arg with
+      | None -> Printf.printf " %s {%s} ~ _\n" (metaterm_to_string tm) (head2str tm)
+      | Some a ->
+        Printf.printf " %s {%s} ~%B %s {%s}\n" (metaterm_to_string tm) (head2str tm) (compatible_metaterm tm a) (metaterm_to_string a) (head2str a)
+    end terms args ;*)
+  let argArr = Array.make (List.length terms) None in
+  List.iter (function
+      | Some a ->
+        let pa = ref (-1) in
+        List.iteri (fun i t ->
+          if !pa < 0 && argArr.(i) = None && compatible_metaterm t a then pa := i
+        ) terms;
+        if !pa < 0 then
+          failwithf "Hypothesis [%s] is not compatible with any subgoal" (metaterm_to_string a)
+        else
+          argArr.(!pa) <- Some a
+      | None -> ()
+    ) args;
+  (* Printf.printf "applys get %d args and produces %d terms\n" (List.length args) (Array.length argArr); *)
+  (* Fix induction hyps *)
+  List.iteri (fun i t -> if argArr.(i) = None then
+    match t with
+      | Pred (_, r) when r <> Irrelevant ->
+        List.iter (fun hyp ->
+          if compatible_metaterm t hyp then
+            argArr.(i) <- Some hyp
+        ) hyps
+      | _ -> ()
+  ) terms;
+  Array.to_list argArr
 
-let head2str metatm = match metatm with
-  | Eq (tm1, tm2) -> term_head_nametag_str tm1 ^ "=" ^ term_head_nametag_str tm2
-  | Pred (tm, _) -> "P " ^ term_head_nametag_str tm
-  | _ -> "~~" *)
-
-let apply_arrow ?(applys=false) term args =
+let apply_arrow ?(applys=false) term args hyps =
   (* Printf.eprintf "Applying term: %s\n" (metaterm_to_string term);
    * List.iter begin fun arg ->
    *   match arg with
@@ -1299,34 +1328,7 @@ let apply_arrow ?(applys=false) term args =
    *   | Some a ->
    *      Printf.eprintf "Applied args: %s\n" (metaterm_to_string a)
    *   end args; *)
-  let args = if not applys then args else begin
-      let terms = (map_args (fun x -> x) term) in
-      (*
-        Printf.printf "Applying term: %s\n" (metaterm_to_string term);
-        List.iter2 begin fun tm arg ->
-          match arg with
-          | None -> Printf.printf " %s {%s} ~ _\n" (metaterm_to_string tm) (head2str tm)
-          | Some a ->
-            Printf.printf " %s {%s} ~%B %s {%s}\n" (metaterm_to_string tm) (head2str tm) (compatible_metaterm tm a) (metaterm_to_string a) (head2str a)
-        end terms args ;*)
-      (* naive: match first *)
-      let argArr = Array.make (List.length terms) None in
-      List.iter (function
-          | Some a ->
-            let pa = ref (-1) in
-            List.iteri (fun i t ->
-              if !pa < 0 && argArr.(i) = None && compatible_metaterm t a then pa := i
-            ) terms;
-            if !pa < 0 then
-              failwithf "Hypothesis [%s] is not compatible with any subgoal" (metaterm_to_string a)
-            else
-              argArr.(!pa) <- Some a
-          | None -> ()
-        ) args;
-      (* Printf.printf "applys get %d args and produces %d terms\n" (List.length args) (Array.length argArr); *)
-      Array.to_list argArr
-      (*; failwith "apply_arrow applys not implemented!" *)
-    end in
+  let args = if not applys then args else genCompatibleArgs term args hyps in
   let () = check_restrictions
       (map_args term_to_restriction term)
       (List.map some_term_to_restriction args)
@@ -1387,7 +1389,7 @@ let try_with_state_all ~fail f =
       | TypesNotFullyDetermined
         -> set_scoped_bind_state state ; fail
 
-let apply ?(applys=false) ?(used_nominals=[]) term args =
+let apply ?(applys=false) ?(used_nominals=[]) term args hyps =
   let hyp_support = metaterm_support term in
   let support = hyp_support @
                   List.flatten_map (Option.map_default metaterm_support []) args in
@@ -1399,7 +1401,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args =
   let process_bindings foralls nablas body =
     match nablas with
     | [] -> (* short circuit *)
-        apply_arrow (freshen_nameless_bindings ~support ~ts:0 foralls body) args ~applys
+        apply_arrow (freshen_nameless_bindings ~support ~ts:0 foralls body) args hyps ~applys
     | _ ->
         let n = List.length nablas in
         let (nabla_ids, nabla_tys) = List.split nablas in
@@ -1428,7 +1430,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args =
                 let alist = List.combine nabla_ids nominals in
                 let permuted_body =
                   replace_metaterm_vars alist raised_body in
-                Some (apply_arrow permuted_body args ~applys)
+                Some (apply_arrow permuted_body args hyps ~applys)
                 )
           end |>
         (function
@@ -1444,7 +1446,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args =
   | Binding(Nabla, nablas, body) ->
       process_bindings [] nablas body
   | Arrow _ ->
-      apply_arrow term args ~applys
+      apply_arrow term args hyps ~applys
   | term when args = [] ->
       (term, [])
   | _ ->
@@ -1496,12 +1498,12 @@ let rec instantiate_withs term withs =
       (normalize (nabla binders' body), nominals @ used_nominals)
   | _ -> (term, [])
 
-let apply_with ?applys:(applys=false) term args withs =
+let apply_with ?applys:(applys=false) term args withs hyps =
   if args = [] && withs = [] && not applys then
     (term, [])
   else
   let term, used_nominals = instantiate_withs term withs in
-  apply (normalize term) args ~used_nominals ~applys
+  apply (normalize term) args hyps ~used_nominals ~applys
 
 (* Backchain *)
 

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1283,9 +1283,15 @@ let rec compatible_metaterm formal actual = match formal, actual with
   | Pred (fm, fr), Pred (am, ar) -> compatible_term fm am && compatible_restriction fr ar
   | _ -> false
 
+(* naive: match first *)
 let genCompatibleArgs term args hyps =
-  (* naive: match first *)
-  let terms = (map_args (fun x -> x) term) in
+  let tmBody = match term with
+    | Binding(Forall, _, Binding(Nabla, _, body)) -> body
+    | Binding(Forall, _, body) -> body
+    | Binding(Nabla, _, body) -> body
+    | _ -> term (* apply will throw an error if the shape is not H1 -> H2 -> H3 *)
+  in
+  let terms = (map_args (fun x -> x) tmBody) in
   (*
     Printf.printf "Applying term: %s\n" (metaterm_to_string term);
     List.iter2 begin fun tm arg ->
@@ -1320,7 +1326,7 @@ let genCompatibleArgs term args hyps =
   ) terms;
   Array.to_list argArr
 
-let apply_arrow ?(applys=false) term args hyps =
+let apply_arrow term args =
   (* Printf.eprintf "Applying term: %s\n" (metaterm_to_string term);
    * List.iter begin fun arg ->
    *   match arg with
@@ -1328,7 +1334,6 @@ let apply_arrow ?(applys=false) term args hyps =
    *   | Some a ->
    *      Printf.eprintf "Applied args: %s\n" (metaterm_to_string a)
    *   end args; *)
-  let args = if not applys then args else genCompatibleArgs term args hyps in
   let () = check_restrictions
       (map_args term_to_restriction term)
       (List.map some_term_to_restriction args)
@@ -1390,6 +1395,7 @@ let try_with_state_all ~fail f =
         -> set_scoped_bind_state state ; fail
 
 let apply ?(applys=false) ?(used_nominals=[]) term args hyps =
+  let args = if not applys then args else genCompatibleArgs term args hyps in
   let hyp_support = metaterm_support term in
   let support = hyp_support @
                   List.flatten_map (Option.map_default metaterm_support []) args in
@@ -1401,7 +1407,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args hyps =
   let process_bindings foralls nablas body =
     match nablas with
     | [] -> (* short circuit *)
-        apply_arrow (freshen_nameless_bindings ~support ~ts:0 foralls body) args hyps ~applys
+        apply_arrow (freshen_nameless_bindings ~support ~ts:0 foralls body) args
     | _ ->
         let n = List.length nablas in
         let (nabla_ids, nabla_tys) = List.split nablas in
@@ -1430,7 +1436,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args hyps =
                 let alist = List.combine nabla_ids nominals in
                 let permuted_body =
                   replace_metaterm_vars alist raised_body in
-                Some (apply_arrow permuted_body args hyps ~applys)
+                Some (apply_arrow permuted_body args)
                 )
           end |>
         (function
@@ -1446,7 +1452,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args hyps =
   | Binding(Nabla, nablas, body) ->
       process_bindings [] nablas body
   | Arrow _ ->
-      apply_arrow term args hyps ~applys
+      apply_arrow term args
   | term when args = [] ->
       (term, [])
   | _ ->

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1257,17 +1257,12 @@ let some_term_to_restriction t =
 exception TypesNotFullyDetermined
 
 
-
 let compatible_term formal actual =
   let f_hname = term_head_name formal in
   let a_hname = term_head_name actual in
   let f_hty = term_head_ty formal in
   let a_hty = term_head_ty actual in
   f_hname = a_hname || (eq_ty f_hty a_hty && not (Filename.check_suffix (ty_to_string f_hty) "-> prop"))
-
-(*let rec compatible_term formal actual = match observe formal, observe actual with
-  | Lam (tyf, tmf), Lam (tya, tma) -> tyf = tya && compatible_term tmf tma
-  | _, _ -> true*)
 
 let compatible_restriction formal actual = match formal, actual with
   | Smaller i, Smaller j when i = j -> true
@@ -1288,23 +1283,13 @@ let rec compatible_metaterm formal actual = match formal, actual with
   | Pred (fm, fr), Pred (am, ar) -> compatible_term fm am && compatible_restriction fr ar
   | _ -> false
 
-let tag2str = function
-  | Constant -> "c"
-  | Eigen -> "e"
-  | Logic -> "l"
-  | Nominal -> "n"
-let term_head_tag tm = 
-  match term_head tm with
-  | None -> assert false
-  | Some (h, _) -> (term_to_var h).tag
-
-let term_head_nametag_str tm = 
+(* let term_head_nametag_str tm = 
   ty_to_string (term_head_ty tm) ^ " " ^ term_head_name tm
 
 let head2str metatm = match metatm with
   | Eq (tm1, tm2) -> term_head_nametag_str tm1 ^ "=" ^ term_head_nametag_str tm2
   | Pred (tm, _) -> "P " ^ term_head_nametag_str tm
-  | _ -> "~~"
+  | _ -> "~~" *)
 
 let apply_arrow ?(applys=false) term args =
   (* Printf.eprintf "Applying term: %s\n" (metaterm_to_string term);
@@ -1314,18 +1299,34 @@ let apply_arrow ?(applys=false) term args =
    *   | Some a ->
    *      Printf.eprintf "Applied args: %s\n" (metaterm_to_string a)
    *   end args; *)
-  if applys then begin
-    let terms = (map_args (fun x -> x) term) in (
-      Printf.printf "Applying term: %s\n" (metaterm_to_string term);
-      List.iter2 begin fun tm arg ->
-        match arg with
-        | None -> Printf.printf " %s {%s} ~ _\n" (metaterm_to_string tm) (head2str tm)
-        | Some a ->
-          Printf.printf " %s {%s} ~%B %s {%s}\n" (metaterm_to_string tm) (head2str tm) (compatible_metaterm tm a) (metaterm_to_string a) (head2str a)
-      end terms args
-    );
-    failwith "apply_arrow applys not implemented!"
-  end;
+  let args = if not applys then args else begin
+      let terms = (map_args (fun x -> x) term) in
+      (*
+        Printf.printf "Applying term: %s\n" (metaterm_to_string term);
+        List.iter2 begin fun tm arg ->
+          match arg with
+          | None -> Printf.printf " %s {%s} ~ _\n" (metaterm_to_string tm) (head2str tm)
+          | Some a ->
+            Printf.printf " %s {%s} ~%B %s {%s}\n" (metaterm_to_string tm) (head2str tm) (compatible_metaterm tm a) (metaterm_to_string a) (head2str a)
+        end terms args ;*)
+      (* naive: match first *)
+      let argArr = Array.make (List.length terms) None in
+      List.iter (function
+          | Some a ->
+            let pa = ref (-1) in
+            List.iteri (fun i t ->
+              if !pa < 0 && argArr.(i) = None && compatible_metaterm a t then pa := i
+            ) terms;
+            if !pa < 0 then
+              failwithf "Hypothesis [%s] is not compatible with any subgoal" (metaterm_to_string a)
+            else
+              argArr.(!pa) <- Some a
+          | None -> ()
+        ) args;
+      (* Printf.printf "applys get %d args and produces %d terms\n" (List.length args) (Array.length argArr); *)
+      Array.to_list argArr
+      (*; failwith "apply_arrow applys not implemented!" *)
+    end in
   let () = check_restrictions
       (map_args term_to_restriction term)
       (List.map some_term_to_restriction args)
@@ -1443,7 +1444,7 @@ let apply ?(applys=false) ?(used_nominals=[]) term args =
   | Binding(Nabla, nablas, body) ->
       process_bindings [] nablas body
   | Arrow _ ->
-      apply_arrow term args
+      apply_arrow term args ~applys
   | term when args = [] ->
       (term, [])
   | _ ->

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1315,7 +1315,7 @@ let apply_arrow ?(applys=false) term args =
           | Some a ->
             let pa = ref (-1) in
             List.iteri (fun i t ->
-              if !pa < 0 && argArr.(i) = None && compatible_metaterm a t then pa := i
+              if !pa < 0 && argArr.(i) = None && compatible_metaterm t a then pa := i
             ) terms;
             if !pa < 0 then
               failwithf "Hypothesis [%s] is not compatible with any subgoal" (metaterm_to_string a)

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -1255,8 +1255,58 @@ let some_term_to_restriction t =
   | Some t -> term_to_restriction t
 
 exception TypesNotFullyDetermined
- 
-let apply_arrow term args =
+
+
+
+let compatible_term formal actual =
+  let f_hname = term_head_name formal in
+  let a_hname = term_head_name actual in
+  let f_hty = term_head_ty formal in
+  let a_hty = term_head_ty actual in
+  f_hname = a_hname || (eq_ty f_hty a_hty && not (Filename.check_suffix (ty_to_string f_hty) "-> prop"))
+
+(*let rec compatible_term formal actual = match observe formal, observe actual with
+  | Lam (tyf, tmf), Lam (tya, tma) -> tyf = tya && compatible_term tmf tma
+  | _, _ -> true*)
+
+let compatible_restriction formal actual = match formal, actual with
+  | Smaller i, Smaller j when i = j -> true
+  | Equal i, Smaller j when i = j -> true
+  | Equal i, Equal j when i = j -> true
+  | Irrelevant, _ -> true
+  | _ -> false
+
+let rec compatible_metaterm formal actual = match formal, actual with
+  | True, True -> true
+  | False, False -> true
+  | Eq (ftm1, ftm2), Eq (atm1, atm2) -> compatible_term ftm1 atm1 && compatible_term ftm2 atm2
+  | Obj (_, fr), Obj (_, ar) -> compatible_restriction fr ar
+  | Arrow _, _ -> failwith "Compatible should not deal with Arrows..."
+  | Binding (fb, _, fm), Binding (ab, _, am) -> fb == ab && compatible_metaterm fm am
+  | Or (fm1, fm2), Or (am1, am2) -> compatible_metaterm fm1 am1 && compatible_metaterm fm2 am2
+  | And (fm1, fm2), And (am1, am2) -> compatible_metaterm fm1 am1 && compatible_metaterm fm2 am2
+  | Pred (fm, fr), Pred (am, ar) -> compatible_term fm am && compatible_restriction fr ar
+  | _ -> false
+
+let tag2str = function
+  | Constant -> "c"
+  | Eigen -> "e"
+  | Logic -> "l"
+  | Nominal -> "n"
+let term_head_tag tm = 
+  match term_head tm with
+  | None -> assert false
+  | Some (h, _) -> (term_to_var h).tag
+
+let term_head_nametag_str tm = 
+  ty_to_string (term_head_ty tm) ^ " " ^ term_head_name tm
+
+let head2str metatm = match metatm with
+  | Eq (tm1, tm2) -> term_head_nametag_str tm1 ^ "=" ^ term_head_nametag_str tm2
+  | Pred (tm, _) -> "P " ^ term_head_nametag_str tm
+  | _ -> "~~"
+
+let apply_arrow ?(applys=false) term args =
   (* Printf.eprintf "Applying term: %s\n" (metaterm_to_string term);
    * List.iter begin fun arg ->
    *   match arg with
@@ -1264,6 +1314,18 @@ let apply_arrow term args =
    *   | Some a ->
    *      Printf.eprintf "Applied args: %s\n" (metaterm_to_string a)
    *   end args; *)
+  if applys then begin
+    let terms = (map_args (fun x -> x) term) in (
+      Printf.printf "Applying term: %s\n" (metaterm_to_string term);
+      List.iter2 begin fun tm arg ->
+        match arg with
+        | None -> Printf.printf " %s {%s} ~ _\n" (metaterm_to_string tm) (head2str tm)
+        | Some a ->
+          Printf.printf " %s {%s} ~%B %s {%s}\n" (metaterm_to_string tm) (head2str tm) (compatible_metaterm tm a) (metaterm_to_string a) (head2str a)
+      end terms args
+    );
+    failwith "apply_arrow applys not implemented!"
+  end;
   let () = check_restrictions
       (map_args term_to_restriction term)
       (List.map some_term_to_restriction args)
@@ -1324,7 +1386,7 @@ let try_with_state_all ~fail f =
       | TypesNotFullyDetermined
         -> set_scoped_bind_state state ; fail
 
-let apply ?(used_nominals=[]) term args =
+let apply ?(applys=false) ?(used_nominals=[]) term args =
   let hyp_support = metaterm_support term in
   let support = hyp_support @
                   List.flatten_map (Option.map_default metaterm_support []) args in
@@ -1336,7 +1398,7 @@ let apply ?(used_nominals=[]) term args =
   let process_bindings foralls nablas body =
     match nablas with
     | [] -> (* short circuit *)
-        apply_arrow (freshen_nameless_bindings ~support ~ts:0 foralls body) args
+        apply_arrow (freshen_nameless_bindings ~support ~ts:0 foralls body) args ~applys
     | _ ->
         let n = List.length nablas in
         let (nabla_ids, nabla_tys) = List.split nablas in
@@ -1365,7 +1427,7 @@ let apply ?(used_nominals=[]) term args =
                 let alist = List.combine nabla_ids nominals in
                 let permuted_body =
                   replace_metaterm_vars alist raised_body in
-                Some (apply_arrow permuted_body args)
+                Some (apply_arrow permuted_body args ~applys)
                 )
           end |>
         (function
@@ -1433,12 +1495,12 @@ let rec instantiate_withs term withs =
       (normalize (nabla binders' body), nominals @ used_nominals)
   | _ -> (term, [])
 
-let apply_with term args withs =
-  if args = [] && withs = [] then
+let apply_with ?applys:(applys=false) term args withs =
+  if args = [] && withs = [] && not applys then
     (term, [])
   else
   let term, used_nominals = instantiate_withs term withs in
-  apply (normalize term) args ~used_nominals
+  apply (normalize term) args ~used_nominals ~applys
 
 (* Backchain *)
 


### PR DESCRIPTION
Grammar:
---
```
applys <HYP NAME> [to] <HYP NAMES> [with X1 = T1, ..., Xn = Tn].
applys <HYP NAME> [with X1 = T1, ..., Xn = Tn].
```

Why not `apply`
---
A script like `apply HYP to _ _ _ H1 _ _ H2 _ _.` is tedious to write---the user needs to figure out the correct order of the application, which might not be important for its correctness.

With `applys`, the user may write `applys HYP H2 H1.` and get the same result (if it is very "easy" to re-order the hypothesis).

![image](https://user-images.githubusercontent.com/5207252/65690691-2a450180-e0a2-11e9-9159-9621c68a590b.png)
(I'm not a user of emacs, so I wrote this minimal plugin for SublimeText to use Abella)

What `applys` does:
---
- Iterate over user-specified hypotheses, and try to match them with the assumptions of the lemma in order. The `match` basically checks top-level constructor and induction restrictions. Each hypothesis is put into its first successful match and take the place.
- Supply no hypothesis like `applys HYP.` behaves the same as `applys HYP to _ _ ... _`.
- One may use the underscore `_` to skip one match for the next hypothesis. E.g. `applys IH to _ H1` will require `H1` to have at least 2 matches within assumptions of `IH` (and put `H1` to the second position). The error message "[%s] is not compatible with any subgoal (skip %d/%d)" should be self-explanatory.
- After the steps above, if there are still assumptions that have induction restrictions, try to find proper hypotheses from the current hypothesis list.

Changes to the code:
---
- Grammar
- Abella.Types: the Apply constructor now contains an `applys` switch
- Naive "compatibility" check used to match a hypothesis with an assumption
- A single function `genCompatibleArgs` that hacks the `args`
- Pass in `hyps` from the prover to `apply_with` for fixing induction `Pred`s

User feedback:
---
Unfortunately only I used `applys` during the past weeks. I hardly use the original `apply` for new developments once I had `applys`. It really boosts my efficiency and let me focus more on the logic.
However, I am not a user of the specification logic or coinduction. So I am not sure whether it works together with those features.