### PR TITLE
Fix for recent OCaml versions.

### DIFF
--- a/src/metaterm.ml
+++ b/src/metaterm.ml
@@ -251,7 +251,7 @@ let format_metaterm ff mt =
   pp_open_vbox ff 0 ; begin
     if !show_types then begin
       let noms = metaterm_support mt |>
-                 List.fast_sort (fun n1 n2 -> Pervasives.compare (term_head_name n1) (term_head_name n2))
+                 List.fast_sort (fun n1 n2 -> compare (term_head_name n1) (term_head_name n2))
       in
       if noms <> [] then begin
         pp_open_hovbox ff 1 ; begin

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -364,7 +364,7 @@ let format_vars ff =
       |> List.map
         (fun (x, xtm) -> (Term.tc [] xtm, x))
       |> List.sort
-        (fun (ty1, _) (ty2, _) -> Pervasives.compare ty1 ty2)
+        (fun (ty1, _) (ty2, _) -> compare ty1 ty2)
       |> List.collate_assoc
       |> List.iter (format_typed_vars ff) ;
     end else begin

--- a/test/ext/oUnit.ml
+++ b/test/ext/oUnit.ml
@@ -173,8 +173,8 @@ let rec was_successful results =
   match results with
       [] -> true
     | RSuccess _::t -> was_successful t
-    | RFailure _::t -> false
-    | RError _::t -> false
+    | RFailure _::_ -> false
+    | RError _::_ -> false
 
 (* Events which can happen during testing *)
 type test_event =
@@ -223,11 +223,11 @@ let run_test_tt ?(verbose=false) test =
   let separator2 =
     "----------------------------------------------------------------------" in
   let string_of_result = function
-      RSuccess path ->
+      RSuccess _ ->
 	if verbose then "ok\n" else "."
-    | RFailure (path, _) ->
+    | RFailure (_, _) ->
 	if verbose then "FAIL\n" else "F"
-    | RError (path, _) ->
+    | RError (_, _) ->
 	if verbose then "ERROR\n" else "E"
   in
   let report_event = function

--- a/test/test_helper.ml
+++ b/test/test_helper.ml
@@ -59,7 +59,7 @@ let process_decls decls =
   sign := List.fold_left add_decl !sign decls ;
   sr := List.fold_left Subordination.update !sr
     (List.filter_map
-       (function Abella_types.SType(ids, ty) -> Some ty | _ -> None)
+       (function Abella_types.SType(_, ty) -> Some ty | _ -> None)
        decls)
 
 let () = process_decls (parse_decls eval_sig_string)
@@ -149,7 +149,7 @@ let renumber_term t =
     | Term.Var _ | Term.DB _ -> t
     | Term.Lam (tycx, t) ->
         let (dep, tycx) = List.fold_left begin
-          fun (dep, tycx) (v, ty) ->
+          fun (dep, tycx) (_, ty) ->
             let xv = "x" ^ string_of_int dep in
             let dep = dep + 1 in
             let tycx = (xv, ty) :: tycx in
@@ -202,7 +202,7 @@ let assert_string_list_equal lst1 lst2 =
 let assert_raises_any ?msg (f: unit -> 'a) =
   let str = "expected exception, but no exception was raised." in
     match raises f, msg with
-      | Some e, _ -> ()
+      | Some _, _ -> ()
 	  | None, None -> assert_failure str
 	  | None, Some s -> assert_failure (Format.sprintf "%s\n%s" s str)
 

--- a/test/test_metaterm.ml
+++ b/test/test_metaterm.ml
@@ -3,7 +3,6 @@ open Test_helper
 open Term
 open Term.Notations
 open Metaterm
-open Typing
 
 let var_a = uvar Eigen "A" 0
 let var_b = uvar Eigen "B" 0
@@ -313,7 +312,7 @@ let tests =
              match
                fresh_raised_alist ~used:[] ~sr ~tag:Eigen ~support tids
              with
-               | ([(x, rx); (y, ry)], [x'; y']) ->
+               | ([(_, rx); (_, ry)], [x'; y']) ->
                    assert_term_pprint_equal ((term_to_string x') ^ " n1 n2") rx ;
                    assert_term_pprint_equal ((term_to_string y') ^ " n2") ry ;
                | _ -> assert false

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -1,8 +1,5 @@
 open OUnit
 open Test_helper
-open Metaterm
-open Lexer
-open Parser
 open Typing
 
 let assert_uterm_pprint_equal s t =

--- a/test/test_subordination.ml
+++ b/test/test_subordination.ml
@@ -1,7 +1,6 @@
 open OUnit
 open Test_helper
 open Term
-open Term.Notations
 open Subordination
 
 let tm = tybase (atybase "tm")

--- a/test/test_tactics.ml
+++ b/test/test_tactics.ml
@@ -365,9 +365,9 @@ let apply_tests =
              apply_with h [None] [("X", nominal_var "n1" ity)]
            in
              match obligations with
-               | [Eq(t1, t2)] ->
+               | [Eq(_, t2)] ->
                    begin match observe (hnorm t2) with
-                     | App(h, [n]) ->
+                     | App(_, [n]) ->
                          assert_term_pprint_equal "n1" n ;
                      | _ -> assert_failure "Unexpected term"
                    end
@@ -761,7 +761,7 @@ let case_tests =
            let term = freshen "{L |- p1 A}" in
            let clauses = parse_clauses "p1 X :- p2 X." in
              match case ~clauses term with
-               | [case1; case2] -> begin
+               | [case1; _] -> begin
                    (* case2 is the member case *)
                    set_bind_state case1.bind_state ;
                    match case1.new_hyps with
@@ -808,7 +808,7 @@ let case_tests =
            let defs = parse_defs "rel1 M N." in
            let term = freshen "rel1 (A (n1:i)) B" in
              match case ~defs term with
-               | [case1] -> ()
+               | [_] -> ()
                | cases -> assert_expected_cases 1 cases) ;
 
       "Should raise over nominal variables in clauses" >::
@@ -816,7 +816,7 @@ let case_tests =
            let clauses = parse_clauses "eq M N." in
            let term = freshen "{eq (A (n1:i)) B}" in
              match case ~clauses term with
-               | [case1] -> ()
+               | [_] -> ()
                | cases -> assert_expected_cases 1 cases) ;
 
       "Should raise when nabla in predicate head" >::
@@ -945,7 +945,7 @@ let case_tests =
                | [case1] ->
                    set_bind_state case1.bind_state ;
                    begin match case1.new_hyps with
-                     | [hyp1; hyp2] ->
+                     | [_; hyp2] ->
                          assert_pprint_equal "sr_a_b (X n1) (Y n2 n1)" hyp2 ;
                      | _ -> assert_failure "Expected 2 new hypotheses"
                    end

--- a/test/test_typing.ml
+++ b/test/test_typing.ml
@@ -3,7 +3,6 @@ open Test_helper
 open Typing
 open Term
 open Metaterm
-open Prover (* Need global signature *)
 
 let dummy_pos = (Lexing.dummy_pos, Lexing.dummy_pos)
 

--- a/test/test_unify.ml
+++ b/test/test_unify.ml
@@ -20,7 +20,7 @@ let rec extract path t =
   match path, observe (hnorm t) with
     | L::tl, Lam(_,t) -> extract tl t
     | A::tl, App(_,t::_) -> extract tl t
-    | H::tl, App(t,_) -> observe t
+    | H::_, App(t,_) -> observe t
     | _ -> assert false
 
 let assert_raises_occurs_check f =


### PR DESCRIPTION
This is a minimal-necessary-to-compile-cleanly fix for #123.  I needed to make this patch in order to get [Homebrew](https://brew.sh/) to build Abella at all.  Merge whenever conditions are clear.  😄 