### PR TITLE
The reprove top-level command

### DIFF
--- a/src/abella_types.ml
+++ b/src/abella_types.ml
@@ -66,6 +66,7 @@ type top_command =
   | Theorem of id * string list * umetaterm
   | Define of flavor * tyctx * udef_clause list
   | Import of string * (string * string) list
+  | Reprove
   | Specification of string
   | Query of umetaterm
   | Kind of id list * knd
@@ -264,6 +265,7 @@ let top_command_to_string tc =
           (withs |>
            List.map (fun (a, b) -> a ^ " := " ^ b) |>
            String.concat ", ")
+    | Reprove -> "Reprove"
     | Specification filename ->
         sprintf "Specification \"%s\"" filename
     | Query q ->

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -32,6 +32,7 @@
     "Kind",          KKIND ;
     "Query",         QUERY ;
     "Quit",          QUIT ;
+    "Reprove",       REPROVE ;
     "Set",           SET ;
     "Show",          SHOW ;
     "Specification", SPECIFICATION ;

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -111,7 +111,7 @@
 %token IND INST APPLY CASE FROM SEARCH TO ON WITH INTROS CUT ASSERT CLAUSEEQ
 %token SKIP UNDO ABORT COIND LEFT RIGHT MONOTONE IMPORT BY ASYNC
 %token SPLIT SPLITSTAR UNFOLD ALL KEEP CLEAR SPECIFICATION SEMICOLON
-%token THEOREM DEFINE PLUS CODEFINE SET ABBREV UNABBREV QUERY SHOW
+%token THEOREM DEFINE PLUS CODEFINE SET ABBREV UNABBREV QUERY REPROVE SHOW
 %token PERMUTE BACKCHAIN QUIT UNDERSCORE AS SSPLIT RENAME
 %token BACK RESET
 %token COLON RARROW FORALL NABLA EXISTS WITNESS STAR AT HASH OR AND
@@ -198,6 +198,7 @@ id:
   | QUERY         { "Query" }
   | QUIT          { "Quit" }
   | RENAME        { "rename" }
+  | REPROVE       { "Reprove" }
   | RIGHT         { "right" }
   | SEARCH        { "search" }
   | SET           { "Set" }
@@ -731,6 +732,8 @@ pure_top_command:
     { Types.Import($2, []) }
   | IMPORT QSTRING WITH import_withs DOT
     { Types.Import($2, $4) }
+  | REPROVE DOT
+    { Types.Reprove }
   | SPECIFICATION QSTRING DOT
     { Types.Specification($2) }
   | KKIND id_list knd DOT


### PR DESCRIPTION
This PR implements the feature requested by #133.

I refer to the original feature request and comment on my modifications:

The command added to Abella is `Reprove`, since most of the top-level commands are capitalized.

> Check that the last Top-level command was, in fact, Theorem. The reprove keyword should not be allowed immediately following a Definition, for example.

The check is done by a `last_top_command` variable introduced.

> Check that the previous theorem has a completed proof.

The normal behavior of top-level commands is that one cannot invoke during the proof status. I don't check if the last proof was accepted, aborted, or partially skipped.

> Reinstate the previous theorem and start reading the following text as a new proof of that theorem.

This is done by re-invoking the last `Theorem` command.

Example:
```
Theorem test_reprove : forall (a : o), a = a.
search.
Reprove.
intros. search.
Reprove.
intros. assert a = a. search.
```