### PR TITLE
Basic tactical support

### DIFF
--- a/src/abella.ml
+++ b/src/abella.ml
@@ -632,7 +632,6 @@ and process_proof_command input =
         | _e                 -> recover_state state
       end
   | SemiColon(cmd1, cmd2)         -> begin
-        Printf.fprintf !out "SEMI: %s\n%!" (command_to_string input) ;
         add_pending_command cmd2 ;
         process_proof_command cmd1 ;
         process_pending_commands ()

--- a/src/abella_types.ml
+++ b/src/abella_types.ml
@@ -136,6 +136,9 @@ type clear_mode =
 type hhint = id option
 
 type command =
+  | Solve of command
+  | Try of command
+  | SemiColon of command * command
   | Induction of int list * hhint
   | CoInduction of id option
   | Apply of depth_bound option * clearable * clearable list * (id * uterm) list * hhint
@@ -301,8 +304,12 @@ let ewitness_to_string = function
   | ETerm t -> uterm_to_string t
   | ESub (x, t) -> x ^ " = " ^ uterm_to_string t
 
-let command_to_string c =
+let rec command_to_string c =
   match c with
+    | Solve(cmd) -> "solve " ^ command_to_string cmd
+    | Try(cmd) -> "try " ^ command_to_string cmd
+    | SemiColon(cmd1, cmd2) ->
+      "(" ^ command_to_string cmd1 ^ " ; " ^ command_to_string cmd2 ^ ")"
     | Induction(is, hn) ->
         sprintf "%sinduction on %s" (hn_to_string hn)
           (String.concat " " (List.map string_of_int is))

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -74,9 +74,11 @@
     "search",        SEARCH ;
     "sig",           SIG ;
     "skip",          SKIP ;
+    "solve",         SOLVE ;
     "split",         SPLIT ;
     "split*",        SPLITSTAR ;
     "to",            TO ;
+    "try",           TRY ;
     "true",          TRUE ;
     "type",          TYPE ;
     "unabbrev",      UNABBREV ;

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -139,15 +139,16 @@ let rec process_pending_commands () =
 
 let process_command_subgoal subgoal =
   let state = snapshot_state () in
-  let subgoal_processed = try begin
+  let subgoals_processed = try begin
+      subgoals := [] ;
       subgoal () ;
       process_pending_commands () ;
       let state_subgoal = snapshot_state () in
-      [fun () -> recover_state_maingoal state_subgoal]
-    end with (End_proof _reason) -> []
+      [fun () -> recover_state_maingoal state_subgoal] @ !subgoals
+    end with (End_proof _reason) -> !subgoals
   in
-  recover_state_maingoal state ;
-  subgoal_processed
+  recover_state state ;
+  subgoals_processed
 
 let format_subgoals subgoals =
   let pristine = State.snapshot () in

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -192,8 +192,8 @@ let add_subgoals ?(mainline) new_subgoals =
   in
   let processed_subgoals = List.map process_command_subgoal annotated_subgoals |> List.concat
   in
-  Printf.fprintf !out "Generating %d subgoals\n%!" (List.length processed_subgoals);
-  format_subgoals processed_subgoals;
+  (* Printf.fprintf !out "Generating %d subgoals\n%!" (List.length processed_subgoals); *)
+  (* format_subgoals processed_subgoals; *)
   subgoals := processed_subgoals @ !subgoals
 
 let fresh_hyp_name base =

--- a/src/prover.ml
+++ b/src/prover.ml
@@ -49,6 +49,7 @@ type sequent = {
   mutable count : int ;
   mutable name : string ;
   mutable next_subgoal_id : int ;
+  mutable pending_commands : command list;
 }
 
 (* The vars = sq.vars is superfluous, but forces the copy *)
@@ -59,7 +60,8 @@ let assign_sequent sq1 sq2 =
   sq1.goal <- sq2.goal ;
   sq1.count <- sq2.count ;
   sq1.name <- sq2.name ;
-  sq1.next_subgoal_id <- sq2.next_subgoal_id
+  sq1.next_subgoal_id <- sq2.next_subgoal_id ;
+  sq1.pending_commands <- sq2.pending_commands
 
 let sequent =
   State.make ~copy:cp_sequent ~assign:assign_sequent {
@@ -69,6 +71,7 @@ let sequent =
     count = 0 ;
     name = "" ;
     next_subgoal_id = 1 ;
+    pending_commands = [] ;
   }
 
 let add_global_types tys knd =
@@ -97,6 +100,65 @@ let close_types sign clauses atys =
   end ;
   sr := Subordination.close !sr atys;
   List.iter (Typing.term_ensure_subordination !sr) (List.map snd clauses)
+
+exception End_proof of [`completed | `aborted]
+
+let copy_sequent () = cp_sequent sequent
+let set_sequent other = assign_sequent sequent other
+
+type prover_state = bind_state * sequent * subgoal list
+
+let snapshot_state () =
+  let bind_state = get_bind_state () ; in
+  let seq = copy_sequent () ; in
+  let subgls = !subgoals in
+  (bind_state, seq, subgls)
+
+let recover_state (bind_state, seq, subgls) =
+  set_bind_state bind_state ;
+  set_sequent seq ;
+  subgoals := subgls
+
+let recover_state_maingoal (bind_state, seq, _subgls) =
+  set_bind_state bind_state ;
+  set_sequent seq
+
+
+let add_pending_command command =
+  sequent.pending_commands <- command :: sequent.pending_commands
+
+let process_proof_command = ref (fun _input -> ())
+
+let rec process_pending_commands () =
+  match sequent.pending_commands with
+  | cmd :: cmds ->
+      sequent.pending_commands <- cmds;
+      !process_proof_command cmd;
+      process_pending_commands ()
+  | [] -> ()
+
+let process_command_subgoal subgoal =
+  let state = snapshot_state () in
+  let subgoal_processed = try begin
+      subgoal () ;
+      process_pending_commands () ;
+      let state_subgoal = snapshot_state () in
+      [fun () -> recover_state_maingoal state_subgoal]
+    end with (End_proof _reason) -> []
+  in
+  recover_state_maingoal state ;
+  subgoal_processed
+
+let format_subgoals subgoals =
+  let pristine = State.snapshot () in
+  List.iter begin fun set_state ->
+    set_state () ;
+    Printf.fprintf !out "[Subgoal %s%s: %s]\n%!"
+      sequent.name
+      (if sequent.name = "" then "" else " ")
+      (metaterm_to_string (normalize sequent.goal))
+  end subgoals ;
+  State.reload pristine
 
 let add_subgoals ?(mainline) new_subgoals =
   let extend_name i =
@@ -127,10 +189,11 @@ let add_subgoals ?(mainline) new_subgoals =
         in
         annotate sequent.next_subgoal_id new_subgoals @ [new_mainline]
   in
-  subgoals := annotated_subgoals @ !subgoals
-
-let copy_sequent () = cp_sequent sequent
-let set_sequent other = assign_sequent sequent other
+  let processed_subgoals = List.map process_command_subgoal annotated_subgoals |> List.concat
+  in
+  Printf.fprintf !out "Generating %d subgoals\n%!" (List.length processed_subgoals);
+  format_subgoals processed_subgoals;
+  subgoals := processed_subgoals @ !subgoals
 
 let fresh_hyp_name base =
   if base = "" then begin
@@ -603,8 +666,6 @@ let get_stmt_clearly h =
 let get_arg_clearly = function
   | Keep ("_", _) -> None
   | arg -> Some (get_stmt_clearly arg)
-
-exception End_proof of [`completed | `aborted]
 
 let next_subgoal () =
   match !subgoals with


### PR DESCRIPTION
Implement #121.

Summary
---
Support Coq-like semi-colons, `try` and `solve` tactics.
`induction on 1. intros. case H1; try case H2; search.`

Implementation details
---
The implementation patches `sequent` by adding a `pending_commands : command list`.
- When a semi-colon is applied, the first part is executed, and the second part is added to the pending list.
- When a subgoal is to be added to the goal list, process its pending commands and add all the subgoals it produces to the goal list.

Due to OCaml's restriction on dependencies (a function must be **defined** before usage), a dirty workaround is used on the function `process_proof_command`, by manually "link" the function when the program starts.
It avoids refactoring the code on a large scale (across existing modules). And I'm happy to hear any better ideas (given that I'm not an experienced programmer in OCaml).

Experience
---
I've been using this feature for around 2 months (and also another Ph.D. in my group for weeks). No problems are found so far.
In addition to the `applys` feature, a lot of uninteresting proof scripts can be eliminated, for example,
`induction on 1. intros. case H1; try applys IH; try search.`
or multiple tactics in combination,
`induction on 1. intros. case H1; try (case H2; case H3; applys IH; search).`

Future directions
---
- Perhaps the square bracket and bar operations `[ tactic1 | tactic2 ... ]` might be helpful in some cases.
- Sometimes, `search` may hang for a large amount of time (unprovable case, perhaps exponential time), which may cause `try search` to be less useful. But in general, this does not happen that often.


I don't mean to push the dev on extending features. But I really hope that these little features may help users who use Abella heavily, being 100% backward-compatible without changing any core logic of Abella.
