### PR TITLE
Fix missing error locations

### DIFF
--- a/src/source.ml
+++ b/src/source.ml
@@ -33,8 +33,10 @@ open struct
         let mtime = Unix.((stat source).st_mtime)
         let dir = Some (Filename.dirname path)
         let lex with_positions =
-          Stdlib.open_in_bin path
-          |> Lexing.from_channel ~with_positions
+          let ch = Stdlib.open_in_bin path in
+          let lb = Lexing.from_channel ~with_positions ch in
+          Lexing.set_filename lb source;
+          lb
       end in
       (module Source : SOURCE)
     end
@@ -164,7 +166,7 @@ open struct
       let lex with_positions =
         let ch = Stdlib.open_in_bin cache_file in
         let lb = Lexing.from_channel ~with_positions ch in
-        lb.lex_curr_p <- { lb.lex_curr_p with pos_fname = source } ;
+        Lexing.set_filename lb source;
         lb
     end in
     return (module Src : SOURCE)
@@ -198,7 +200,7 @@ open struct
       let lex with_positions =
         let ch = Stdlib.open_in_bin cache_name in
         let lb = Lexing.from_channel ~with_positions ch in
-        lb.lex_curr_p <- { lb.lex_curr_p with pos_fname = source } ;
+        Lexing.set_filename lb source;
         lb
     end in
     return (module Src : SOURCE)

--- a/src/source.ml
+++ b/src/source.ml
@@ -26,17 +26,19 @@ open struct
 
   exception Fail
 
+  let lex source path with_positions =
+    let ch = Stdlib.open_in_bin path in
+    let lb = Lexing.from_channel ~with_positions ch in
+    Lexing.set_filename lb source;
+    lb
+
   let open_local_file =
     Result.wrap begin fun source ->
       let module Source = struct
         let path = source
         let mtime = Unix.((stat source).st_mtime)
         let dir = Some (Filename.dirname path)
-        let lex with_positions =
-          let ch = Stdlib.open_in_bin path in
-          let lb = Lexing.from_channel ~with_positions ch in
-          Lexing.set_filename lb source;
-          lb
+        let lex with_positions = lex source path with_positions
       end in
       (module Source : SOURCE)
     end
@@ -163,11 +165,7 @@ open struct
           fields.host
           (Filename.dirname fields.path)
         |> Option.some
-      let lex with_positions =
-        let ch = Stdlib.open_in_bin cache_file in
-        let lb = Lexing.from_channel ~with_positions ch in
-        Lexing.set_filename lb source;
-        lb
+      let lex with_positions = lex source cache_file with_positions
     end in
     return (module Src : SOURCE)
 
@@ -197,11 +195,7 @@ open struct
       let path = source
       let mtime = stat.st_mtime
       let dir = None
-      let lex with_positions =
-        let ch = Stdlib.open_in_bin cache_name in
-        let lb = Lexing.from_channel ~with_positions ch in
-        Lexing.set_filename lb source;
-        lb
+      let lex with_positions = lex source cache_name with_positions
     end in
     return (module Src : SOURCE)
 


### PR DESCRIPTION
Error locations are broken for local files since e8bcebd. Fixed by setting the lexbufs filename. Also replaced 

    lb.lex_curr_p <- { lb.lex_curr_p with pos_fname = source } ;

with the [equivalent stdlib call](https://github.com/ocaml/ocaml/blob/e1e81b410631b4444f66335cc378ddb65ba0a2f3/stdlib/lexing.ml#L186)

    Lexing.set_filename lb source

